### PR TITLE
Add a link to 20190531 Capsicum notes

### DIFF
--- a/capsicum/20190531.md
+++ b/capsicum/20190531.md
@@ -28,9 +28,10 @@
     - [procdesc: fix reparenting when the debugger is attached](https://reviews.freebsd.org/D20361)
     - [procdesc: allow to collect status through wait(1) if process is traced](https://reviews.freebsd.org/D20362)
   - Previous Capsicum calls have covered these sorts of issues; David recalls
-    writing a document with lots of questions and now answers (and will try to
-    locate it again)
-- [Syzkaller work at the Hackathon](https://wiki.freebsd.org/Syzkaller), Mark 
+    writing a document with lots of questions and few answers (and will try to
+    locate it again):
+    - [EDIT: doc from 2015 found and [made available here](https://lurklurk.org/procdesc/procdesc.html)]
+- [Syzkaller work at the Hackathon](https://wiki.freebsd.org/Syzkaller), Mark
   used `cap_enter` as an example of adding new system calls to Syzkaller
   - Teaching Syzkaller about `cap_rights_limit` and just passing junk in the
    rights is likely to be interesting too


### PR DESCRIPTION
Add link to document about process descriptor semantics that
was discussed in 2015.