### PR TITLE
README: FreeBSD workflow working group, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 Notes from meetings of various FreeBSD-related groups.
 
 Several working groups in the FreeBSD project hold periodic meetings via
-conference calls, video conferences, or other means.  This repository
-aims to provide a central location to publish public notes of those meetings.
+conference calls, video conferences, or other means. This repository
+aims to provide a central location for the notes.
 
-Meeting notes are formatted in MarkDown.  Filenames should use a
+Notes are formatted in Markdown.  Filenames should use a
 *YYYYMMDD* prefix.
 
 Directory | Description
 --- | ---
-bhyve/ | Working group focused on the bhyve hypervisor
-capsicum/ | Capsicum framework development and application of Capsicum
-git-wg/ | Subversion to Git Migration Working Group
-graphics/ | Working group focused on the graphics stack
-iflib/ | Working group focused on the iflib driver framework
-mitigations/ | OS-based vulnerability mitigations
+[bhyve](https://github.com/freebsd/meetings/tree/master/bhyve) | The bhyve hypervisor
+[capsicum](https://github.com/freebsd/meetings/tree/master/capsicum) | Capsicum framework development and application of Capsicum
+[git-wg](https://github.com/freebsd/meetings/tree/master/git-wg) | Subversion to Git Migration
+[graphics](https://github.com/freebsd/meetings/tree/master/graphics) | The graphics stack
+[iflib](https://github.com/freebsd/meetings/tree/master/iflib) | The iflib driver framework
+[mitigations](https://github.com/freebsd/meetings/tree/master/mitigations) | OS-based vulnerability mitigations
+
+Notes elsewhere include: 
+
+* FreeBSD workflow working group https://gitlab.com/bsdimp/freebsd-workflow


### PR DESCRIPTION
Add a link out to the repo for FreeBSD workflow working group. 

Whilst here: 

* Markdown (not MarkDown)
* conciseness
* links.