### PR TITLE
Graphics: README: notes are not fortnightly

### DIFF
--- a/graphics/readme.md
+++ b/graphics/readme.md
@@ -1,3 +1,3 @@
 # Graphics Team Meetings
 
-We get together every two weeks to discuss current issues relating to graphics.
+Occasional get-togethers, some of which include note-taking.


### PR DESCRIPTION
Follow-up to <https://wiki.freebsd.org/action/info/Graphics?action=diff&rev2=92&rev1=91>. 

Here at <https://github.com/freebsd/meetings/tree/master/graphics>, the most recent notes were around nine months ago. Have a simpler README; for readers to not wonder about more recent notes.