### PR TITLE
workflow: consolidate notes from gitlab.com/bsdimp/freebsd-workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Directory | Description
 [graphics](https://github.com/freebsd/meetings/tree/master/graphics) | The graphics stack
 [iflib](https://github.com/freebsd/meetings/tree/master/iflib) | The iflib driver framework
 [mitigations](https://github.com/freebsd/meetings/tree/master/mitigations) | OS-based vulnerability mitigations
+[workflow](https://github.com/freebsd/meetings/tree/master/workflow)    | Contributor experience improvement
 
-Notes elsewhere include: 
+Notes elsewhere include:
 
 * FreeBSD workflow working group https://gitlab.com/bsdimp/freebsd-workflow

--- a/workflow/20211020.md
+++ b/workflow/20211020.md
@@ -1,0 +1,93 @@
+# 2021-10-20 Workflow Refinement Working Group
+
+Attending:
+* Warner Losh (imp@)
+* Glen Barber (gjb@)
+* Brooks Davis (brooks@)
+* Alan Somers (asomers@)
+* Merv Hammer
+* Dave Cottlehuber (dch@)
+* Shawn Webb
+* Faraz Vahedi
+* Konstantin Belousov (kib@)
+* Ed Maste (emaste@)
+* Stefan Esser (se@)
+
+Tried to attend but couldn't due to inaccessible format despite raising concerns with the organizer weeks ago:
+* Pau Amma
+
+## Agenda (copied from agenda.md file, to be editing during the meeting)
+
+Our next meeting is at 19:00 UTC October 20, 2021.
+
+Meeting	link: https://meet.google.com/jhc-qgry-qda
+
+- Welcome
+- Set Working Group Goals
+  - We need a plan for a plan
+  - We need to partition the work
+- Subgroups
+  - Now the right time to create them?
+- Meeting Times
+  - How often?
+  - Split times to allow more participation?
+  - Best way to meet
+  - - Pau Amma: something text-based so I can attend.
+
+- what to focus on
+    - CI
+    - Github pull request vs Gitlab merge request
+    - kib: Linear History on main branch highly desirable
+    - swebb: likes
+    - brooks: would like to see more merges
+    - merv: linear history scales better than histories that support merges
+    - had feeder branches certified as stable before going into main branch
+    - kib: not a huge harm from having a commit that's broken
+        - Maybe better to fix it to build the generated files at kernel build time not checkin time
+        - Does this imply not doing per-commit/per-push CI builds?
+    - build is shorter than running all of the tests
+    - phabricator needs to stick around for a long time, at least so we can go look at context for old commits.
+    - docs (including manual pages) probably have different CI requirements (check markup, render), and need fast turnover not to get thrown off the groove
+
+## CI
+
+- aren't full builds on each commit painful? (merv@)
+- not too bad in practice, look at Cheri's example from brooks@
+- we have some options from Microsoft etc (imp@)
+- ports might need some care, many core builds are heavy on the dependencies (most compilers) (dch@)
+- tests are more important, and heavier usage (kib@)
+- what about speeding builds? ccache, NO_CLEAN, skipping compiler (gjb@)
+
+next steps
+
+- consensus we should do this
+- do some experiments to get a feel for costs
+
+## Code Reviews
+
+- the elephant - what about phab??
+- we need to keep phab at least readonly because context & history is critical (kib)
+- self-hosted stuff means a lot of possibilities for breakage, accounts, maintenance (shawn)
+- where do we keep the history - should we use mailboxes for this? (dch@)
+- conflicting reports - integrated tools suck vs too many accounts (imp@)
+
+## BugZilla
+
+- Working well enough
+- Finding information a little harder
+- Should look at more integrated things, but there's not a huge gain over what we have
+- We likely should customize it further
+
+## GitHub/GitLab
+
+- self hosted vs 3rd party hosted is a later discussion
+- For 3rd party hosting, deplatforming is a concern
+- OAUTH issues using third-party authentication (twitter, facebook, google, etc.) during an external outage should also be considered
+- Have plenty of other issues to consider first
+
+## Meta issues
+
+- Single sign in, OAUTH, etc to support github/gitlab/google/etc
+- Tends to be friction because they are all separate
+- there is a massive amount of "project" tooling and automation, as well as personal committers stuff
+- information overload

--- a/workflow/20211027.md
+++ b/workflow/20211027.md
@@ -1,0 +1,55 @@
+# FreeBSD Git / Workflow Working Group Agenda
+
+Attendees:
+* Warner Losh (imp@)
+* Glen Barber (gjb@)
+* Merv Hammer
+* Marc Branchaud
+* Kristof Provost (kp@)
+* Konstantin Belousov (kib@)
+* Ed Maste (emaste@)
+* Ken Bynell
+* Stefan Esser (se@)
+* Brooks Davis (brooks@)
+
+Deprived of a way to attend for the second time going, despite raising the issue 7 weeks ago: Pau Amma
+
+This document contains the agenda for the next meeting.
+
+Our next meeting is at 19:00 UTC October 27, 2021.
+
+Meeting link: https://meet.google.com/jhc-qgry-qda
+
+We'll take notes at: https://hackmd.io/ydgsBTHZTj6Ne9qoqOn1Ng
+
+- Welcome
+- Set Working Group Goals: Continue working on a plan
+  - Create a few major items and put name(s) next to each of them
+    - CI on (lwhsu, asommers, merv hammer?)
+        - Running on 'runners', most FreeBSD version are available
+        - CirrusCI can run anything we publish tot the cloud
+        - CirrusCI will need care and feeding so downstream projects aren't broken
+        - Cheri has config files that call back to their Jenkins servers
+        - Brooks can provide copies of config files for us adopt for FreeBSD
+        - Warner will talk with lwshu to gauge the interest in all the details of the CHERI's CI system.
+        - Triggers only against some branches
+        - CHERI cuts a lot of things out to make things faster.
+    - Bugzilla (koobs)
+        - It's koobs' baby
+    - Phabricator
+        - Revisit after 3 months
+    - Long term goals for FreeBSD Project document
+        - Little current interest
+    - Short term pain points to focus on
+      - git arc improvements
+      - phabricator / git integration
+      - documentation
+    - Others?
+  - Get rough timelines for each of these
+- Next Meeting
+  - Time to be friendlier to Asia
+  - Next week, early Wednesday Asia time, late Tuesday for
+    everybody else.
+  - Request for text-only meetings: poll for sentiment
+      - Pau Amma would like to go on record as objecting that letting him attend depends on public sentiment and not on the code of conduct.
+      - People have noted that there's a transcript / close captioning feature in Google meet that can provide real-time closed captions to the meeting that are mostly accurate (but with some issues with names and foreign words or both).

--- a/workflow/20211104.md
+++ b/workflow/20211104.md
@@ -1,0 +1,94 @@
+# FreeBSD Git / Workflow Working Group Agenda
+
+Attendees:
+* Warner Losh (imp@)
+* Li-Wen Hsu (lwhsu@)
+* Philip Paeps (philip@)
+* Kubilay Kocak (koobs@)
+ 
+This document contains the agenda for the next meeting.
+
+Our next meeting is at 03:00 UTC November 4, 2021
+
+Meeting link: https://meet.google.com/jhc-qgry-qda
+
+We'll take notes at: https://hackmd.io/ydgsBTHZTj6Ne9qoqOn1Ng
+
+- Welcome
+    - Philip wants to learn about the cluster stuff and offload Li-Wen
+    - Li-Wen wants to expand the cluster, not just for CI but for other groups as well
+    - Li-Wen's time is limited for this (should be better in Q4)
+    - Finishing git commit hooks and move those into a repo so that we can get patches / changes (either as an individual repo or admin branch)
+    - Continue working on pre-commit test and building release artifact with CI
+    - Koobs most interested in high level and where we have overlaps between the tools or the flows.
+        - github admin
+        - wiki admin
+        - bugmeister / bugzilla
+- Current CI state and how to move some tasks into before the commit CI pipelines
+    - What work is there?
+    - What needs to be done?
+    - Building images, testing, running virtual machines
+    - All these tests are in freebsd-ci repo (it's still an experiment with many hackish workaroundse)
+    - Goal of CI repo
+        - Make them as general as possible, not tied to Jenkins
+        - Hopefully we can integrate these scripts into other systems
+        - Also use artifacts of the CI process to be used by others (RE, snapshots)
+        - Before we can have a gitlab/github need some polishing.
+        - Next step setup a local gitlab instance
+        - Integration with Phabricator difficult due to subversions (git may make this easier due to diff git patch integretiy)
+        - Help refine build/test machine and scripts in the CI repo -- how to get them into the src tree
+        - Checking the status of current test harness and fixing the broken test failures (li-wen 10-15% of time).
+        - amd64 + current enabled sending stability issues for test failues.
+        - Ultimate goal is for CI repo to go away and move it into base repo
+    - Tasks others can do
+        - Others expiment with using the CI in other systems outside of Jenkins.
+        - Fixing broken tests today
+    - make verify -- works but requires a lot of other setup, sysctl, and other environmental things
+        - Open task: reduce the dependencies
+        - Documentation on how to run smaller tests (eg cd src/bin/cat; make test to run unit tests)
+    - Setup on-site gitlab instance to understand the nuts and bolts of using it.
+    - The goal of having in-depth testing, we'll need to do a lot more than to just connect a few things to github and gitlab. The tests are more complicated and require a number of machines: VMs, physical servers, embedded boards, etc. Managing this complexity will be a challenge.
+        - How do we integrate all this? Most other projects are user space
+    - Developers and contributors need to be able to pinpoint the problem and reproduce the problem in small way. How do we make this easier. Some of this can be solved by documention, some by evagalizing, much will need to be solved by making the test harness easier to use and for developers to run a single test in a debugging env.
+- Current state of Bugzilla
+    - Had bugzilla for 12 years
+    - Koobs interested in how we use the systems
+- Larger work flow issues
+    - Better support for smaller increments
+    - May have some cultural changes
+    - Have a good set of guiding principles
+    - "big bang migrations"
+    - Philip prefers more independent tools
+    - Integration between code review and issue tracking
+    - Possible Task: evaluating bug reports and code reviews in the same place
+    - Short term vs long term focus
+    - Koobs suggests having an 'acceptance criteria' document that spells out our larger goals and what are the community's needs.
+    - Key problem today: lowering friction. We need people to contribute to the project to keep it alive.
+        - Duplication
+        - Unlinked systems
+        - Make 4 or 5 systems turn into 2 or 3 we'd be in good shape.
+    - How well do the different systems integrate and how much effort do we need go to use them.
+- Actionable next steps
+    - Create a brief set of goals
+    - Do we want to setup experiments
+    - Bitesized actionable items
+        - eg can we import the freebsd repo
+        - eg can we import the bug database
+        - eg can we accept PR/MR requests with $GITHOSTING thing, how does it work
+            - github PR setup now
+            - gitlab?
+        - can we do integration of code review and bugs
+            - can we create a fork that tries to integrate into bugzilla
+            - can we import phab history into gitlab to see how well it scale
+    - GOAL ? : HAVE PATCHES AND BUGS IN THE SAME PLACE
+    - Phab is good for developer to developer reviews, but doesn't fit so well with contributors contributed.
+    - How to do the handoff between phan to bugzilla to tree...
+    - Easier for fresh blood to submit bugs / patches / etc and get not only patches but also grow some of them into committers.
+    - How do we live in the 'drive by PR open source culture'?
+    - git work flow: uli did experiments, he got a cluster machine, did the conversion etc.
+    - Need to start gathring open question, possible options, what experiments are suggested, what research can flow from that.
+
+- NEXT STEPS
+    - Boil this down into a few actionable items
+    - gitlab data import experiments
+    - Followup on the suggestion for recording meetings and meeting ping-ponging

--- a/workflow/agenda.md
+++ b/workflow/agenda.md
@@ -1,0 +1,23 @@
+# FreeBSD Git / Workflow Working Group Agenda
+
+NOTE: Prior meeting notes can be found at https://gitlab.com/bsdimp/freebsd-workflow
+
+Attendees:
+* Warner Losh (imp@)
+ 
+This document contains the agenda for the next meeting.
+
+Our next meeting is at 18:00 UTC November 10, 2021
+
+Meeting link: https://meet.google.com/jhc-qgry-qda
+
+We'll take notes at: https://hackmd.io/ydgsBTHZTj6Ne9qoqOn1Ng
+
+- Welcome
+- Discuss shifts in how we're doing things
+  - Recording this meeting
+  - Rotating schedule to mix groups
+      - 1800 UTC -> 2200 UTC -> 0300 UTC
+      - View meetings as every 3rd week, with the 2200 time slot for exchange. Can tweak the times a little since overlap needed is smaller.
+  - Move some things to email / shared docs
+  - Try to break items down into actionable actions

--- a/workflow/index.md
+++ b/workflow/index.md
@@ -1,0 +1,87 @@
+FreeBSD Work Flow Working group
+===============================
+
+This repository contains various working documents for the FreeBSD work flow
+improvement group.
+
+Next meeting info link:/meetings/agenda.md[here]
+
+.This working group's efforts is focused on the following areas:
+. Creating CI pipelines
+. What to do about Phabricator
+. What to do about Bugzilla
+. Best way to accept pull requests
+. Making it easier to find relevant feedback
+. Vendor Import Issues
+. Repo integrity
+
+== Creating CI pipeline
+
+Currently, we use Jenkins to run a CI pipeline after each commit.
+However, this is done after the commits are made.
+It's difficult for developers to run themselves before commits.
+Not currently integrated into gitlab or github CI infrastructure.
+
+The focus of the working group will be to see what we can do to increase access to CI pipelines.
+
+In addition, due to our large testing matrix, are there smart ways that we can optimize the pipelines.
+
+What testing and experimentaiton do we need to do for us to make our decisions?
+
+== Phabricator
+
+The main developers of Phabricator have announced that it is at EOL.
+They will not continue to maintain it.
+Community efforts, lead primarily by wikimedia, has sprung up.
+
+.Current questions to consider:
+* The question that needs to be answered is what do we do with Phabricator?
+* Do we join the community efforts to keep it alive?
+* Do we stand up another service?
+* Do we move to something else hosted elsewhere?
+** Github has code review on its pull requests
+** Gitlab has code review for its modification requests
+
+== Bugzilla
+
+The project has used Bugzilla for some time now.
+We've done some unnatural things with it.
+We've also done some cool things to automate some workflows in the project.
+
+* Does Bugzilla fit our needs?
+* Are we doing things in Bugzilla that are better done with other tools?
+** Pull Requests
+** Maintainer Feedback
+** ExpRun management
+
+== Pull Requests
+
+A lot of people want to accept pull requests.
+Today, the project will land pull requests that wind up in github mirror, but we don't guarantee that.
+We have some CI pipelines that run for pull requests, but coverage is weak.
+
+* Should Pull Requests be the primary way to get things into the tree?
+* Is there a service that we should use for this?
+* What's the relative merits of gitlab vs github for this service?
+* Do we want a single point that flows into the tree, or multiple flows into the tree + tooling?
+** There's much diversity in how open source projects do this, we should survey to find out what's working and what's not.
+
+== Information Overload
+
+One of the big complaints with project has been dropped patches.
+Another complaint from developers is that it's hard to find relevant information to into the tree.
+How do we address these issues?
+
+== Vendor Import Issues
+
+We currently have an OK vendor import, but there's problems with it.
+
+* must use `git bisect start --first-parent` only
+* openzfs branch doesn't have non-zfs FreeBSD files
+* Tag for each import (is this a problem?)
+* Why not submodules?
+* Alternatively, why not `git subtree merge --squash`?
+
+== Repo Integrity
+
+Do we want to sign all commits?


### PR DESCRIPTION
During a conversation with @allanjude he showed me yet another place where meeting notes are stored
(https://gitlab.com/bsdimp/freebsd-workflow)

The repo on gitlab seems to be abandoned, so I decided to consolidate notes in one place.

